### PR TITLE
Create GitHub Pages bundle for Qualitätsprojekt documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ Dieses Repository enthält das Organisationshandbuch der VHS Lahnstein. Die Kapi
 - [09 – Anhang](kapitel/09-anhang/index.md)
 
 Jedes Kapitel liegt in einem eigenen Unterordner innerhalb von `kapitel/` und enthält eine `index.md` mit allen bisherigen Inhalten des Abschnitts.
+
+## Veröffentlichung auf GitHub Pages
+
+Für die Veröffentlichung der Dokumentation als zusammenhängendes DIN-A4-Dokument wurde unter `docs/` eine eigenständige Website hinterlegt. GitHub Pages kann so konfiguriert werden, dass der Ordner `docs/` als Quelle dient.
+
+1. Öffne die Repository-Einstellungen auf GitHub und aktiviere **Pages**.
+2. Wähle als Quelle `main`/`work` (je nach Standardbranch) und den Ordner **/docs**.
+3. Nach der Veröffentlichung ist die Dokumentation unter `https://<username>.github.io/<repository>/` abrufbar.
+
+Der Einstiegspunkt `docs/index.html` lädt alle Kapitel aus `docs/content/` und stellt sie als einzelne Seiten im DIN-A4-Layout dar. Die Layout-Vorgaben sind in `docs/assets/styles.css` hinterlegt. Die Markdown-Kapitel wurden mit dem Repository synchronisiert, so dass Aktualisierungen durch Kopieren in den `docs/content/` Ordner auf der Website sichtbar werden.

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,0 +1,139 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  background-color: #f4f5f7;
+}
+
+body {
+  margin: 0;
+  background: var(--page-bg, #f4f5f7);
+}
+
+header {
+  text-align: center;
+  padding: 2rem 1rem 0;
+  color: #1f2933;
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.2rem;
+}
+
+header p {
+  margin: 0 auto 1.5rem;
+  max-width: 680px;
+  color: #52606d;
+}
+
+main {
+  padding: 0 0 4rem;
+}
+
+.loading,
+.error {
+  text-align: center;
+  color: #52606d;
+  margin-top: 2rem;
+  font-size: 1rem;
+}
+
+.error {
+  color: #ab1c32;
+}
+
+.page {
+  background: #ffffff;
+  width: 210mm;
+  min-height: 297mm;
+  margin: 0 auto 2.5rem;
+  padding: 20mm;
+  box-sizing: border-box;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  border-radius: 12px;
+  color: #1f2933;
+}
+
+.page > :first-child {
+  margin-top: 0;
+}
+
+.page h1,
+.page h2,
+.page h3,
+.page h4 {
+  color: #102a43;
+}
+
+.page a {
+  color: #1d4ed8;
+}
+
+.page table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+}
+
+.page table th,
+.page table td {
+  border: 1px solid #d9e2ec;
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+}
+
+.page ul,
+.page ol {
+  margin-left: 1.2rem;
+}
+
+footer {
+  text-align: center;
+  color: #9aa5b1;
+  padding-bottom: 2rem;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1024px) {
+  .page {
+    width: calc(100% - 2rem);
+    min-height: auto;
+    padding: 2rem;
+  }
+}
+
+@page {
+  size: A4;
+  margin: 20mm;
+}
+
+@media print {
+  :root {
+    background-color: #ffffff;
+  }
+
+  body {
+    background: #ffffff;
+  }
+
+  header,
+  footer {
+    display: none;
+  }
+
+  main {
+    padding: 0;
+  }
+
+  .page {
+    margin: 0 auto;
+    box-shadow: none;
+    border-radius: 0;
+    page-break-after: always;
+  }
+
+  .page:last-of-type {
+    page-break-after: auto;
+  }
+}

--- a/docs/content/01-rahmendaten-und-kontext.md
+++ b/docs/content/01-rahmendaten-und-kontext.md
@@ -1,0 +1,34 @@
+# 1 · Rahmendaten und Kontext
+
+## 1.1 Steckbrief der VHS Lahnstein
+
+- **Träger & Rechtsform:** Die Volkshochschule Lahnstein wird als gemeinnütziger Verein geführt, mit Vorstand, regelmäßiger Kassenprüfung und ausgelagerter Buchhaltung.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L39-L44】
+- **Finanzierung:** Die Mittel speisen sich aus Förderprogrammen (u. a. BAMF, ADD, ESF, DigiNetz), Teilnahmeentgelten sowie Einzelspenden und Sponsoring.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L41-L43】
+- **Standort & Ressourcen:** Die VHS nutzt angemietete Räumlichkeiten in Lahnstein und organisiert dort Kursräume, Technik und Frontoffice selbst.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L41-L43】【F:kapitel/07-themen-und-fazit/index.md†L13-L21】
+- **Teamgröße:** Sieben Mitarbeitende inklusive Geschäftsführung arbeiten überwiegend in Teilzeit- bzw. Minijobmodellen und stimmen sich hybrid vor Ort sowie aus dem Homeoffice ab.【F:kapitel/06-kommunikation/index.md†L56-L58】
+
+## 1.2 Qualitätsmanagement-Anlass
+
+Die Dokumentation entsteht im Rahmen der ZBQ-Rezertifizierung. Das Programm fordert eine nachvollziehbare Beschreibung von Strukturdaten, Qualitätszielen und Ergebnissen, begrenzt auf 15 Seiten plus Anlagen.【F:Dokumentationsformular_ZBQ_2025.txt†L1-L47】 Um die Anforderungen zu erfüllen und Wissen langfristig zu sichern, fasst die Qualitätsgruppe die gelebten Abläufe in einem Organisationshandbuch zusammen.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L3-L24】
+
+## 1.3 Projektauftrag und Zielprodukt
+
+- **Projektart:** Qualitätsprojekt „Erstellung Organisationshandbuch“ zur Vorbereitung der Rezertifizierung.【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+- **Leistungsumfang:** Modularer Aufbau mit neun Kapiteln, die Rollen, Prozesse, Infrastruktur, Dokumente, Kommunikation sowie Evaluationsinstrumente beschreiben.【F:README.md†L1-L18】
+- **Arbeitsweise:** Grundlage sind acht leitfadengestützte Interviews (60–90 Minuten, Whisper-Transkription), ergänzt um vorhandene Qualitätsdokumente wie Selbstreport, Formularpakete und Projektauswahlmatrix.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L30-L34】【F:Quellen/Dokumentationsformular_ZBQ_2025.txt†L25-L47】【F:kapitel/07-themen-und-fazit/index.md†L3-L67】
+
+## 1.4 Stakeholder und Rollen im Projekt
+
+- **Qualitätsgruppe:** Verwaltung (BAMF/Nicht-BAMF), Einstufung, IT/Web sowie Geschäftsführung arbeiteten gemeinsam an Struktur, Inhalten und Validierung des Handbuchs.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L200】【F:kapitel/06-kommunikation/index.md†L5-L53】
+- **Externe Anspruchsgruppen:** BAMF, Jobcenter, ADD, Bildungsministerium RLP sowie Verbände liefern Förderlogiken, Prüfkriterien und Berichtspflichten, die im Handbuch abgebildet werden.【F:kapitel/06-kommunikation/index.md†L27-L43】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L18】
+- **Nutzer:innen:** Mitarbeitende, Vertretungen und neue Kolleg:innen verwenden die Dokumentation für Onboarding, Vertretbarkeit und Nachweisführung.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L7-L24】
+
+## 1.5 Rahmenbedingungen für das Qualitätsprojekt
+
+- **Zeitliche Taktung:** Analyse, Redaktion und Validierung wurden in aufeinander aufbauenden Arbeitspaketen umgesetzt (Interviews → Strukturierung → Themen- und Evaluationsplanung).【F:Dokumentation Qualitätsprojekt/06-zeitplan-und-meilensteine.md†L5-L21】
+- **Veränderungsdruck:** Unterschiedliche Ablagepraktiken, informelle Kommunikationswege und neue Programme wie DigiNetz erfordern einheitliche Standards und klare Zuständigkeiten.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L21-L62】【F:kapitel/06-kommunikation/index.md†L14-L53】【F:kapitel/07-themen-und-fazit/index.md†L13-L67】
+- **Erfolgskriterien:** Transparenz, Vertretbarkeit und kontinuierliche Verbesserungszyklen gelten als Maßstab für die Wirksamkeit des Projekts.【F:kapitel/07-themen-und-fazit/index.md†L3-L76】【F:kapitel/09-anhang/index.md†L3-L67】
+- **Träger:** Volkshochschule Lahnstein e. V. (gemeinnütziger Verein mit Vorstand, Kassenprüfung und ausgelagerter Buchhaltung).【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L1-L47】
+- **Projektart:** Qualitätsprojekt im Rahmen der Rezertifizierung nach ZBQ (Dokumentation max. 15 Seiten zzgl. Anlagen).【F:Dokumentationsformular_ZBQ_2025.txt†L1-L37】
+- **Zielsetzung des Handbuchs:** Orientierung im Alltag, Sicherung von Wissen, Unterstützung für Zertifizierungen sowie Onboarding und Vertretungen.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L1-L24】
+- **Struktur des Endprodukts:** Modularer Aufbau mit neun Kapiteln (Inhaltsverzeichnis, Einleitung, Rollen, Prozesse, Infrastruktur, Dokumentenmanagement, Kommunikation, Themen/Fazit, Anhang).【F:README.md†L1-L18】

--- a/docs/content/02-ausgangslage-und-motivation.md
+++ b/docs/content/02-ausgangslage-und-motivation.md
@@ -1,0 +1,13 @@
+# 2 · Ausgangslage und Motivation
+
+## 2.1 Ausgangslage vor Projektstart
+
+Die VHS Lahnstein arbeitet mit einem kleinen, stark arbeitsteiligen Team. Viele Abläufe sind routiniert, basieren jedoch auf persönlichem Erfahrungswissen und mündlichen Absprachen.【F:kapitel/07-themen-und-fazit/index.md†L3-L21】【F:kapitel/06-kommunikation/index.md†L14-L53】 Dokumentenablagen, Benennungslogiken und Kommunikationsketten unterscheiden sich je Kursart; verbindliche Checklisten oder Standards lagen nur teilweise vor.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L21-L62】
+
+## 2.2 Handlungsdruck und Risiken
+
+Die Rezertifizierung nach ZBQ verlangt eine nachvollziehbare Darstellung von Prozessen, Zuständigkeiten und Ergebnissen innerhalb enger Dokumentationsgrenzen.【F:Dokumentationsformular_ZBQ_2025.txt†L1-L47】 Ohne ein konsolidiertes Organisationshandbuch drohten Wissensverluste bei Vertretungen, Medienbrüche zwischen CMX und Papierablagen sowie fehlende Nachweise gegenüber Fördermittelgebern.【F:kapitel/03-prozesse/index.md†L96-L160】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L21-L62】
+
+## 2.3 Motivation und erwartete Wirkung
+
+Die Qualitätsgruppe wollte Transparenz schaffen, Vertretbarkeit sichern und kontinuierliche Verbesserungen ermöglichen. Dazu sollte das Handbuch Rollenprofile, Prozessketten und Dokumentanforderungen zusammenführen, Quick Wins priorisieren und ein Evaluationsinstrument etablieren.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L200】【F:kapitel/07-themen-und-fazit/index.md†L13-L76】【F:kapitel/09-anhang/index.md†L3-L67】 So entsteht ein dauerhaft nutzbares Nachschlagewerk für Mitarbeitende und ein belastbarer Nachweis gegenüber Prüfinstanzen.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L3-L24】【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】

--- a/docs/content/03-leitfragen-und-projektziele.md
+++ b/docs/content/03-leitfragen-und-projektziele.md
@@ -1,0 +1,66 @@
+# 3 · Leitfragen und Projektziele
+
+## 3.1 Herleitung und Kontext
+
+Die Qualitätsgruppe leitete die Leitfragen direkt aus den ZBQ-Anforderungen und dem Zweck des Organisationshandbuchs ab: Das Handbuch soll Mitarbeitende beim Onboarding, bei Vertretungen und bei Zertifizierungen unterstützen und gleichzeitig die Rezertifizierung belastbar dokumentieren.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L3-L24】【F:Dokumentationsformular_ZBQ_2025.txt†L1-L37】 Die Interviews zu Rollen, Prozessen und Dokumenten machten deutlich, dass Transparenz über Zuständigkeiten, Schnittstellen und Evaluationswege Voraussetzung für nachhaltige Qualitätsarbeit ist.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L147】【F:kapitel/03-prozesse/index.md†L64-L200】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L62】
+
+## 3.2 Leitfrage 1 – Transparenz über Rollen, Prozesse und Dokumente
+
+### Zielbild und Schwerpunkte
+
+- **Rollenprofilierung:** Alle Kernfunktionen sollen mit Aufgaben, Verantwortlichkeiten, Vertretungsregeln und benötigten Kompetenzen beschrieben sein, damit Übergaben gelingen.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L147】
+- **Prozessklarheit:** Für BAMF- und Nicht-BAMF-Angebote werden die Phasen von der Bedarfserhebung bis zur Abrechnung mit Zuständigkeiten und Dokumenten hinterlegt, inklusive der Synchronität zwischen Kursordnern und CMX.【F:kapitel/03-prozesse/index.md†L64-L200】
+- **Dokumenten-Drehscheibe:** Eine Kursartenmatrix bündelt Nachweise, Formate, Ablageorte und Versandwege, damit Nachweispflichten schnell geprüft werden können.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L52】
+
+### Messbare Projektziele
+
+1. Für jede Rolle liegt ein abgestimmtes Aufgaben- und Schnittstellenprofil vor, das mindestens jährlich überprüft wird.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L147】
+2. Prozessbeschreibungen decken alle Förderlogiken (BAMF, ESF/ADD, Entgeltangebote) ab und verknüpfen Kommunikations- und Dokumentationsschritte eindeutig.【F:kapitel/03-prozesse/index.md†L64-L200】
+3. Der Dokumentenüberblick wird als verbindliche Referenz gepflegt; CMX- und Papierablage sind über eindeutige Benennungsstandards verzahnt.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L61】【F:kapitel/07-themen-und-fazit/index.md†L21-L27】
+
+### Risiken und Folgeaufgaben
+
+- **Uneinheitliche Ablagepraktiken** können die Nachvollziehbarkeit gefährden; deshalb priorisiert das Projekt Checklisten („Originale versenden“, Posteingang) und eine gemeinsame Benennungslogik.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L56-L62】【F:kapitel/07-themen-und-fazit/index.md†L21-L27】【F:kapitel/07-themen-und-fazit/index.md†L71-L76】
+- **Personalwechsel oder Teilzeitmodelle** erfordern gelebte Vertretungen; die Rollenprofile werden in Onboarding- und Vertretungsszenarien getestet.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L93-L147】
+
+## 3.3 Leitfrage 2 – Infrastruktur- und Kommunikationsschnittstellen sichern
+
+### Zielbild und Schwerpunkte
+
+- **Infrastrukturtransparent machen:** IT-, Raum- und Technikzuständigkeiten werden so dokumentiert, dass Supportwege und offene Punkte klar benannt sind.【F:kapitel/06-kommunikation/index.md†L5-L58】【F:kapitel/07-themen-und-fazit/index.md†L28-L39】
+- **Kommunikationsketten nachvollziehbar halten:** Alle wiederkehrenden Meldungen, externen Kontakte und verantwortlichen Personen sind für BAMF- und Nicht-BAMF-Abläufe hinterlegt.【F:kapitel/06-kommunikation/index.md†L5-L58】【F:kapitel/03-prozesse/index.md†L120-L129】
+- **Digitale und analoge Kanäle synchronisieren:** CMX-Änderungen, Website-Pflege und physische Aushänge folgen einem abgestimmten Aktualisierungsrhythmus.【F:kapitel/06-kommunikation/index.md†L14-L34】【F:kapitel/07-themen-und-fazit/index.md†L13-L27】
+
+### Messbare Projektziele
+
+1. Für jede Kommunikationslinie (BAMF, Jobcenter, Verbände, Ministerium) liegt ein aktualisierter Kontakt- und Meldeplan vor.【F:kapitel/06-kommunikation/index.md†L25-L43】
+2. Infrastrukturthemen wie Raumplanung, Technik-Inventar und Account-Basics sind als Quick Wins dokumentiert und mit Verantwortlichkeiten versehen.【F:kapitel/07-themen-und-fazit/index.md†L13-L39】【F:kapitel/07-themen-und-fazit/index.md†L71-L76】
+3. CMX, Homepage und Aushänge werden mindestens alle zwei Wochen abgeglichen; Abweichungen werden protokolliert.【F:kapitel/06-kommunikation/index.md†L14-L34】【F:kapitel/07-themen-und-fazit/index.md†L21-L27】
+
+### Risiken und Folgeaufgaben
+
+- **Informationsverluste bei spontaner Abstimmung** werden durch klar definierte Vertretungen, dokumentierte Meldewege und regelmäßige Review-Termine abgefedert.【F:kapitel/06-kommunikation/index.md†L45-L58】【F:kapitel/07-themen-und-fazit/index.md†L9-L27】
+- **Technikabhängigkeiten** bleiben überschaubar, wenn Mini-Inventar und Passwort-/Account-Regeln umgesetzt werden.【F:kapitel/07-themen-und-fazit/index.md†L28-L39】
+
+## 3.4 Leitfrage 3 – Nachhaltige Verankerung im Qualitätsmanagement
+
+### Zielbild und Schwerpunkte
+
+- **Themen- und Maßnahmenplan etablieren:** Priorisierte Themenpakete mit Zielbild, ersten Schritten (4–6 Wochen) und Review-Termin verankern kontinuierliche Verbesserungen.【F:kapitel/07-themen-und-fazit/index.md†L9-L67】
+- **Feedbackinstrument nutzen:** Ein standardisierter Evaluationsbogen misst Nutzung, Wirkung, Beteiligung und Verbesserungsideen der Mitarbeitenden.【F:kapitel/09-anhang/index.md†L3-L67】
+- **ZBQ-Nachweise systematisch vorbereiten:** Ergebnisse, Maßnahmen und Prüfpfade werden entlang der Projektanforderungen dokumentiert.【F:Dokumentationsformular_ZBQ_2025.txt†L1-L37】
+
+### Messbare Projektziele
+
+1. Mindestens zwei Themenpakete werden pro Rezertifizierungszyklus mit dokumentierten Review-Ergebnissen umgesetzt.【F:kapitel/07-themen-und-fazit/index.md†L9-L76】
+2. Die Evaluation des Handbuchs erfolgt jährlich mittels Fragebogen; Ergebnisse fließen in Kapitel 07 ein.【F:kapitel/09-anhang/index.md†L3-L67】【F:kapitel/07-themen-und-fazit/index.md†L9-L76】
+3. Prüf- und Nachweisunterlagen werden für Audits gebündelt, sodass Projektziele, Maßnahmen und Evidenzen jederzeit abrufbar sind.【F:Dokumentationsformular_ZBQ_2025.txt†L1-L37】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L52】
+
+### Risiken und Folgeaufgaben
+
+- **Überlastung im Tagesgeschäft** kann die Umsetzung der Themenpakete verzögern; daher werden Quick Wins priorisiert und Aufgaben auf mehrere Rollen verteilt.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L147】
+- **Geringe Beteiligung** würde die Wirkung des Handbuchs schmälern; regelmäßige Feedbackformate und klare Einladungen zur Mitwirkung sichern die Nutzung.【F:kapitel/09-anhang/index.md†L3-L67】【F:kapitel/06-kommunikation/index.md†L45-L58】
+
+## 3.5 Zusammenfassung des Zielsystems
+
+Die Leitfragen bilden ein geschlossenes Zielsystem: Rollen- und Prozessklarheit schafft die Grundlage für verlässliche Kommunikation und Infrastruktur, während strukturierte Evaluations- und Themenzyklen die Nachhaltigkeit sichern. Durch die Verzahnung von Rollenprofilen, Prozessketten, Dokumentenstandards und Feedbackschleifen kann die VHS Lahnstein sowohl die Rezertifizierungsanforderungen erfüllen als auch Alltagsprozesse stabilisieren.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L147】【F:kapitel/03-prozesse/index.md†L64-L200】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L61】【F:kapitel/06-kommunikation/index.md†L5-L58】【F:kapitel/07-themen-und-fazit/index.md†L9-L76】【F:kapitel/09-anhang/index.md†L3-L67】【F:Dokumentationsformular_ZBQ_2025.txt†L1-L37】

--- a/docs/content/04-vorgehensweise-und-arbeitspakete.md
+++ b/docs/content/04-vorgehensweise-und-arbeitspakete.md
@@ -1,0 +1,31 @@
+# 4 · Vorgehensweise und Arbeitspakete
+
+## 4.1 Analysephase
+
+- Durchführung und Auswertung von acht leitfadengestützten Interviews (60–90 Minuten) mit Mitarbeitenden, inklusive Doppeltonspuren und Whisper-Transkription zur Sicherung der Aussagen.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L30-L34】
+- Strukturierung der Interviewleitfäden entlang der Themen Rollen, Prozesse, Infrastruktur, Dokumentation und Kommunikation, um Redundanzen und Lücken sichtbar zu machen.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L16-L24】【F:kapitel/03-prozesse/index.md†L60-L136】
+- Sichtung vorhandener Qualitätsdokumente (Selbstreport, Formularpakete, Projektauswahlmatrix) als Ergänzung zur Interviewbasis.【F:Quellen/Dokumentationsformular_ZBQ_2025.txt†L25-L47】【F:kapitel/07-themen-und-fazit/index.md†L3-L67】
+
+## 4.2 Strukturierung und Redaktion
+
+- Aufbau einer modularen Repository-Struktur mit getrennten Markdown-Kapiteln zur gezielten Pflege und Aktualisierung.【F:README.md†L1-L18】
+- Redaktionelle Verdichtung der Interviewinhalte zu Rollenprofilen, Prozessbeschreibungen und Dokumentationsstandards (Kapitel 02–05).【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L1-L200】【F:kapitel/03-prozesse/index.md†L1-L200】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L1-L62】
+- Ergänzung eines Kommunikationskapitels, das interne wie externe Schnittstellen beschreibt und Zuständigkeiten dokumentiert.【F:kapitel/06-kommunikation/index.md†L5-L58】
+- Ableitung eines Evaluationsbogens im Anhang, um zukünftige Aktualisierungen datenbasiert zu priorisieren.【F:kapitel/09-anhang/index.md†L3-L67】
+
+## 4.3 Validierung und Priorisierung
+
+- Ableitung von Themenpaketen und Quick Wins (z. B. Master-Raumplan, Checkliste „Originale versenden“, Mini-Inventar) als Brücke zur Umsetzung der Qualitätsziele.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】
+- Entwicklung eines Evaluationsbogens für Mitarbeitende zur Wirkungskontrolle des Handbuchs.【F:kapitel/09-anhang/index.md†L3-L67】
+- Abgleich der Projektziele mit den ZBQ-Anforderungen, um Nachweise, Indikatoren und Maßnahmen konsistent zu dokumentieren.【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+
+## 4.4 Zusammenarbeit der Qualitätsgruppe
+
+- Regelmäßige Abstimmungen zwischen Verwaltung, Einstufung, IT/Web und Geschäftsführung stellten sicher, dass Schnittstellen früh erkannt und beschrieben wurden.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L200】【F:kapitel/06-kommunikation/index.md†L5-L53】
+- Entscheidungen wurden bewusst leichtgewichtig gehalten (persönliche Treffen, kurze Abstimmungsschleifen), um der Teilzeitstruktur des Teams gerecht zu werden.【F:kapitel/06-kommunikation/index.md†L14-L58】
+- Rückmeldungen aus Alltagssituationen flossen iterativ in die Texte ein, beispielsweise bei der Synchronisierung von CMX und Kursordnern oder der Definition von Postlauf-Prozessen.【F:kapitel/03-prozesse/index.md†L96-L160】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L21-L62】
+
+## 4.5 Ergebnisse der Arbeitsweise
+
+- Das Handbuch bildet heute eine konsistente Referenz, die Onboarding, Vertretungen und Prüfungen unterstützt.【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L7-L24】
+- Quick Wins und Themenpakete ermöglichen kurzfristige Verbesserungen, während Evaluationsbögen die Nachhaltigkeit absichern.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】【F:kapitel/09-anhang/index.md†L3-L67】

--- a/docs/content/05-ergebnisse-je-leitfrage.md
+++ b/docs/content/05-ergebnisse-je-leitfrage.md
@@ -1,0 +1,48 @@
+# 5 · Ergebnisse je Leitfrage
+
+Die Qualitätsgruppe überprüfte alle Leitfragen anhand der projektspezifischen Ziele und der ZBQ-Zielmatrix. Die folgenden Abschnitte bündeln die wichtigsten Ergebnisse, Nachweise und offenen Beobachtungen je Leitfrage.【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+
+## Leitfrage 1: Transparenz über Rollen, Prozesse und Dokumente
+
+### Umsetzungsschwerpunkte
+
+- **Rollenprofilierung:** Das Handbuch beschreibt für alle zentralen Funktionen (Verwaltung BAMF, Einstufung, Frontoffice Nicht-BAMF, IT/EDV, Web/CMX, Geschäftsführung) Aufgaben, Verantwortlichkeiten und Schnittstellen, wodurch Vertretungen möglich werden.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L147】
+- **Prozesslandkarte:** Für BAMF- und Nicht-BAMF-Angebote wurden Phasen, Zuständigkeiten, Unterlagen und Kommunikationsschritte dokumentiert – inklusive Synchronität zwischen CMX-System und physischen Kursordnern.【F:kapitel/03-prozesse/index.md†L64-L200】
+- **Dokumenten-Standards:** Eine Kursarten-Matrix bündelt Nachweise, Formate, Ablageorte und Verantwortlichkeiten und schafft eine verbindliche Drehscheibe für Prüfungen und Audits.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L52】
+
+### Messung und Indikatoren
+
+- Abgestimmte Rollenprofile werden jährlich geprüft und bei Personalwechseln in Onboarding-Gesprächen genutzt.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L85-L147】
+- CMX-Einträge und Kursordner werden mit einer einheitlichen Benennungslogik abgeglichen; Checklisten für Originalversand und Posteingang sichern die Vollständigkeit.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L21-L62】【F:kapitel/07-themen-und-fazit/index.md†L21-L27】【F:kapitel/07-themen-und-fazit/index.md†L71-L76】
+
+**Ergebnis:** Die Leitfrage wurde erfüllt, weil alle Kernrollen, Prozessketten und Dokumentanforderungen konsistent erfasst sind und somit als Referenz für Onboarding, Vertretungen und Zertifizierungsnachweise dienen.
+
+## Leitfrage 2: Dokumentation der Infrastruktur- und Kommunikationsschnittstellen
+
+### Umsetzungsschwerpunkte
+
+- **Infrastrukturübersicht:** Kapitel 04 dokumentiert IT/EDV, Raumressourcen, Supportwege und offene Punkte (z. B. Inventar, Account-Basics), sodass technische Zuständigkeiten transparent werden.【F:kapitel/07-themen-und-fazit/index.md†L13-L39】
+- **Kommunikationswege:** Kapitel 06 listet interne und externe Kontakte, genutzte Kanäle, wiederkehrende Meldungen und Verantwortlichkeiten, womit Übergaben und Abstimmungen nachvollziehbar bleiben.【F:kapitel/06-kommunikation/index.md†L5-L58】
+- **Verzahnung mit Prozessen:** Die Prozesskapitel verknüpfen Schnittstellen (z. B. Jobcenter, BAMF, Verbände) direkt mit den jeweiligen Abläufen und Dokumentenanforderungen.【F:kapitel/03-prozesse/index.md†L120-L129】
+
+### Messung und Indikatoren
+
+- Für Kommunikationslinien (BAMF, Jobcenter, Verbände, Ministerium) existieren aktualisierte Kontakt- und Meldepläne, die im Qualitätszirkel überprüft werden.【F:kapitel/06-kommunikation/index.md†L27-L53】
+- Infrastruktur-Quick-Wins (Mini-Inventar, Passwort-/Account-Regeln, Master-Raumplan) werden innerhalb von 4–6 Wochen umgesetzt und im Themenplan dokumentiert.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】
+
+**Ergebnis:** Die Leitfrage wurde beantwortet, da Infrastruktur- und Kommunikationsschnittstellen nun eindeutig beschrieben und in die Prozessdokumentation integriert sind.
+
+## Leitfrage 3: Nachhaltige Verankerung im Qualitätsmanagement
+
+### Umsetzungsschwerpunkte
+
+- **Themen- und Maßnahmenplan:** Das Fazit-Kapitel definiert priorisierte Themenpakete samt Zielbildern, ersten Schritten und Review-Takten, wodurch kontinuierliche Verbesserungen geplant werden können.【F:kapitel/07-themen-und-fazit/index.md†L9-L67】
+- **Evaluationsinstrument:** Ein standardisierter Mitarbeitendenfragebogen im Anhang misst Nutzung, Wirkung, Beteiligung und Verbesserungsvorschläge zum Handbuch.【F:kapitel/09-anhang/index.md†L3-L67】
+- **Projektanforderungen erfüllt:** Die Dokumentation adressiert die ZBQ-Vorgaben, indem sie Projektziele, Maßnahmen, Ergebnisse und Prüfpfade nachvollziehbar abbildet.【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+
+### Messung und Indikatoren
+
+- Mindestens zwei Themenpakete werden pro Rezertifizierungszyklus mit dokumentierten Review-Ergebnissen umgesetzt und im Handbuch nachgezogen.【F:kapitel/07-themen-und-fazit/index.md†L9-L76】
+- Die jährliche Evaluation liefert quantitative Einschätzungen zu Nutzung, Qualität und Beteiligung und dient als Trigger für Updates.【F:kapitel/09-anhang/index.md†L3-L67】
+
+**Ergebnis:** Die Leitfrage ist beantwortet, weil das Handbuch um konkrete Review-Mechanismen ergänzt wurde, die sowohl Qualitätsziele als auch Nutzerfeedback absichern.

--- a/docs/content/06-zeitplan-und-meilensteine.md
+++ b/docs/content/06-zeitplan-und-meilensteine.md
@@ -1,0 +1,13 @@
+# 6 · Zeitplan und Meilensteine
+
+Der Zeitplan orientiert sich an den ZBQ-Vorgaben sowie an den Arbeitszyklen der VHS. Er verbindet Analyse, Redaktionsarbeit und Umsetzungsplanung, sodass Nachweise rechtzeitig vor der Rezertifizierung vorliegen.【F:Dokumentationsformular_ZBQ_2025.txt†L1-L47】【F:kapitel/07-themen-und-fazit/index.md†L13-L76】
+
+| Zeitraum | Meilenstein | Ergebnis |
+| --- | --- | --- |
+| KW 10–12 | Interviewphase & Transkription | Vollständige Datengrundlage aus acht Gesprächen (Whisper-Transkripte).【F:kapitel/01-einleitung-und-geltungsbereich/index.md†L30-L34】 |
+| KW 13–16 | Redaktion & Strukturierung | Veröffentlichung der Kapitel 01–06 mit Rollen-, Prozess- und Dokumentationsbeschreibungen.【F:README.md†L1-L18】【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L1-L147】 |
+| KW 17–18 | Validierung & Themenplan | Abstimmung Quick Wins, Themenpakete, Erstellung Evaluationsbogen.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】【F:kapitel/09-anhang/index.md†L3-L67】 |
+| KW 19–20 | Abgleich mit ZBQ-Anforderungen | Prüfung der Zielmatrix, Ergänzung von Indikatoren und Nachweispfaden für die Dokumentation.【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】 |
+| Ab KW 21 | Umsetzung Quick Wins & Evaluation | Umsetzung Master-Raumplan, Originalversand-Checkliste, Mini-Inventar; Start der ersten Evaluationsrunde.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】【F:kapitel/09-anhang/index.md†L3-L67】 |
+
+Die Meilensteine werden im Qualitätszirkel fortgeschrieben; Nachsteuerungen (z. B. aufgrund von Fördervorgaben) werden direkt in den Themenplan und die Dokumentation übernommen.【F:kapitel/07-themen-und-fazit/index.md†L9-L76】【F:kapitel/06-kommunikation/index.md†L45-L58】

--- a/docs/content/07-wirkung-und-nachhaltigkeit.md
+++ b/docs/content/07-wirkung-und-nachhaltigkeit.md
@@ -1,0 +1,18 @@
+# 7 · Wirkung und Nachhaltigkeit
+
+Das Qualitätsprojekt schafft einen spürbaren Mehrwert im Tagesgeschäft und liefert zugleich belastbare Nachweise für Prüf- und Förderinstanzen. Wirkung und Verstetigung werden entlang von Transparenz, Rezertifizierung und kontinuierlicher Verbesserung betrachtet.【F:kapitel/07-themen-und-fazit/index.md†L3-L76】【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+
+## 7.1 Kurzfristige Wirkung
+
+- **Transparenzgewinn:** Mitarbeitende können Arbeitsabläufe, Zuständigkeiten und Dokumentationspflichten schnell nachvollziehen, was Fehlerrisiken reduziert und Vertretungen erleichtert.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L147】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L52】
+- **Schnittstellenklarheit:** CMX, Kursordner und Kommunikationswege sind abgestimmt, wodurch Abstimmungen mit Jobcenter, BAMF und Verbänden schneller erfolgen.【F:kapitel/03-prozesse/index.md†L96-L160】【F:kapitel/06-kommunikation/index.md†L27-L53】
+
+## 7.2 Beitrag zur Rezertifizierung
+
+- **Nachweisführung:** Die strukturierte Dokumentation liefert belastbare Nachweise gegenüber Prüfinstanzen und erfüllt die ZBQ-Anforderungen nach nachvollziehbaren Prozessen und Evaluation.【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】【F:kapitel/07-themen-und-fazit/index.md†L9-L76】
+- **Themenplan & Quick Wins:** Priorisierte Maßnahmen (Master-Raumplan, Benennungsstandard, Mini-Inventar) schaffen sichtbare Fortschritte, die in die Rezertifizierungsunterlagen einfließen.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】
+
+## 7.3 Nachhaltige Verankerung
+
+- **Kontinuierliche Verbesserung:** Der Themenplan definiert Review-Termine, während der Evaluationsbogen regelmäßiges Feedback sicherstellt – beides verankert das Handbuch als lebendes Dokument.【F:kapitel/07-themen-und-fazit/index.md†L9-L76】【F:kapitel/09-anhang/index.md†L3-L67】
+- **Wissenssicherung:** Durch klare Verantwortlichkeiten, Checklisten und dokumentierte Abläufe bleiben Know-how und Prozesswissen auch bei Personalwechseln erhalten.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L85-L147】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L21-L62】

--- a/docs/content/08-naechste-schritte.md
+++ b/docs/content/08-naechste-schritte.md
@@ -1,0 +1,21 @@
+# 8 · Nächste Schritte
+
+Die nächsten Schritte priorisieren schnelle Wirkung, sichern Nachweise für die Rezertifizierung und etablieren einen kontinuierlichen Verbesserungszyklus.【F:kapitel/07-themen-und-fazit/index.md†L9-L76】【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+
+## 8.1 Kurzfristig (0–2 Monate)
+
+1. **Quick Wins umsetzen:** Checkliste „Originale versenden“, Master-Raumplan-Quelle und Mini-Inventar priorisieren.【F:kapitel/07-themen-und-fazit/index.md†L71-L76】
+2. **Benennungsstandards festigen:** Kurs-/Modul-IDs als Drehscheibe für CMX, Ordner und Dateinamen in allen Kursarten anwenden.【F:kapitel/07-themen-und-fazit/index.md†L21-L27】
+3. **Evaluationsrunde vorbereiten:** Fragebogen finalisieren, Terminplanung abstimmen und Mitarbeitende informieren.【F:kapitel/09-anhang/index.md†L3-L67】
+
+## 8.2 Mittelfristig (3–6 Monate)
+
+1. **Evaluationsrunde durchführen:** Mitarbeitendenfragebogen verteilen, Ergebnisse zusammenfassen und in Kapitel 07 dokumentieren.【F:kapitel/09-anhang/index.md†L3-L67】【F:kapitel/07-themen-und-fazit/index.md†L9-L76】
+2. **Themenpakete abarbeiten:** Master-Raumplan, DigiNetz-Prozess und Kennzahlenpilot starten und Review-Termine dokumentieren.【F:kapitel/07-themen-und-fazit/index.md†L13-L67】
+3. **Zielüberprüfung für Rezertifizierung:** Ergebnisse und Nachweise gemäß ZBQ-Vorgaben konsolidieren und dem Auditorium zur Verfügung stellen.【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+
+## 8.3 Langfristig (>6 Monate)
+
+1. **Handbuchpflege institutionalisieren:** Jahresplanung für Updates und Review-Sitzungen im Qualitätszirkel verankern.【F:kapitel/07-themen-und-fazit/index.md†L9-L76】
+2. **Digitalisierung schrittweise erweitern:** Scan- und Ablagestrukturen definieren, um CMX und Papierordner dauerhaft zu synchronisieren.【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L21-L62】
+3. **Wirkungskennzahlen entwickeln:** Kleine Kennzahlen-Setups (z. B. Einstufungsdurchlaufzeit, Vollständigkeit Unterlagen) pilotieren und für Entscheidungen nutzen.【F:kapitel/07-themen-und-fazit/index.md†L55-L67】

--- a/docs/content/09-zusammenfassung.md
+++ b/docs/content/09-zusammenfassung.md
@@ -1,0 +1,9 @@
+# 9 · Zusammenfassung
+
+Das Qualitätsprojekt „Erstellung Organisationshandbuch“ stärkt die VHS Lahnstein in drei Dimensionen:
+
+1. **Transparenz & Vertretbarkeit:** Rollenprofile, Prozessketten und Dokumentationsstandards sind konsistent beschrieben und erleichtern Onboarding sowie Urlaubs- oder Krankheitsvertretungen.【F:kapitel/02-rollen-und-verantwortlichkeiten/index.md†L5-L200】【F:kapitel/03-prozesse/index.md†L64-L200】【F:kapitel/05-dokumentenmanagement-und-ablage/index.md†L9-L61】
+2. **Schnittstellenmanagement:** Kommunikationswege, Infrastrukturverantwortlichkeiten und Dokumentationslogiken sind synchronisiert, wodurch externe Partner und Fördermittelgeber schneller bedient werden.【F:kapitel/06-kommunikation/index.md†L5-L58】【F:kapitel/07-themen-und-fazit/index.md†L13-L67】
+3. **Nachhaltige Qualitätsentwicklung:** Quick Wins, Themenpakete und Evaluationsinstrumente verankern kontinuierliche Verbesserungen und liefern belastbare Nachweise für die ZBQ-Rezertifizierung.【F:kapitel/07-themen-und-fazit/index.md†L13-L76】【F:kapitel/09-anhang/index.md†L3-L67】【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】
+
+Damit sind die Voraussetzungen für die anstehende Rezertifizierung und den kontinuierlichen Qualitätsdialog erfüllt.【F:kapitel/07-themen-und-fazit/index.md†L9-L76】【F:Dokumentationsformular_ZBQ_2025.txt†L31-L47】

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dokumentation Qualitätsprojekt</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script defer src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>Dokumentation Qualitätsprojekt</h1>
+      <p>
+        Zusammenführung aller Kapitel als zusammenhängendes Dokument mit 
+        DIN&nbsp;A4-Seitenlayout für die Veröffentlichung über GitHub Pages.
+      </p>
+    </header>
+    <main>
+      <p id="status" class="loading">Inhalte werden geladen …</p>
+      <div id="document"></div>
+    </main>
+    <footer>
+      Erstellt für die Veröffentlichung auf GitHub Pages · Format optimiert für DIN&nbsp;A4.
+    </footer>
+    <script>
+      const sections = [
+        {
+          file: "content/01-rahmendaten-und-kontext.md",
+          heading: "01 – Rahmendaten und Kontext"
+        },
+        {
+          file: "content/02-ausgangslage-und-motivation.md",
+          heading: "02 – Ausgangslage und Motivation"
+        },
+        {
+          file: "content/03-leitfragen-und-projektziele.md",
+          heading: "03 – Leitfragen und Projektziele"
+        },
+        {
+          file: "content/04-vorgehensweise-und-arbeitspakete.md",
+          heading: "04 – Vorgehensweise und Arbeitspakete"
+        },
+        {
+          file: "content/05-ergebnisse-je-leitfrage.md",
+          heading: "05 – Ergebnisse je Leitfrage"
+        },
+        {
+          file: "content/06-zeitplan-und-meilensteine.md",
+          heading: "06 – Zeitplan und Meilensteine"
+        },
+        {
+          file: "content/07-wirkung-und-nachhaltigkeit.md",
+          heading: "07 – Wirkung und Nachhaltigkeit"
+        },
+        {
+          file: "content/08-naechste-schritte.md",
+          heading: "08 – Nächste Schritte"
+        },
+        {
+          file: "content/09-zusammenfassung.md",
+          heading: "09 – Zusammenfassung"
+        }
+      ];
+
+      const statusNode = document.getElementById("status");
+      const docNode = document.getElementById("document");
+
+      async function renderDocument() {
+        try {
+          marked.setOptions({
+            gfm: true,
+            breaks: false,
+            mangle: false,
+            headerIds: true
+          });
+
+          for (const section of sections) {
+            const response = await fetch(section.file);
+            if (!response.ok) {
+              throw new Error(`Konnte ${section.file} nicht laden (${response.status})`);
+            }
+
+            const markdown = await response.text();
+            const html = marked.parse(markdown);
+
+            const page = document.createElement("section");
+            page.className = "page";
+
+            const heading = document.createElement("h1");
+            heading.textContent = section.heading;
+            page.appendChild(heading);
+
+            const contentWrapper = document.createElement("div");
+            contentWrapper.innerHTML = html;
+            page.appendChild(contentWrapper);
+
+            docNode.appendChild(page);
+          }
+
+          statusNode?.remove();
+        } catch (error) {
+          console.error(error);
+          if (statusNode) {
+            statusNode.textContent = "Fehler beim Laden der Inhalte. Bitte versuchen Sie es erneut.";
+            statusNode.className = "error";
+          }
+        }
+      }
+
+      if (typeof marked === "undefined") {
+        statusNode.textContent = "Konvertierungsbibliothek konnte nicht geladen werden.";
+        statusNode.className = "error";
+      } else {
+        renderDocument();
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static GitHub Pages site that aggregates all Qualitätsprojekt chapters into one DIN A4 styled document
- copy the markdown sources into the published docs folder and provide styling for print and screen
- document the activation steps for GitHub Pages in the repository README

## Testing
- manual rendering via python -m http.server --directory docs 8000

------
https://chatgpt.com/codex/tasks/task_e_68e1425dc1208324883d7fdd9f122a73