### PR TITLE
Fix Markdown converter loading on GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dokumentation Qualitätsprojekt</title>
     <link rel="stylesheet" href="assets/styles.css" />
-    <script defer src="assets/marked.min.js"></script>
   </head>
   <body>
     <header>
@@ -65,9 +64,48 @@
       const statusNode = document.getElementById("status");
       const docNode = document.getElementById("document");
 
+      function loadScript(src) {
+        return new Promise((resolve, reject) => {
+          const script = document.createElement("script");
+          script.src = src;
+          script.defer = true;
+          script.onload = () => resolve();
+          script.onerror = () =>
+            reject(new Error(`Konnte ${src} nicht laden.`));
+          document.head.appendChild(script);
+        });
+      }
+
+      async function ensureMarked() {
+        if (window.marked) {
+          return window.marked;
+        }
+
+        const sources = [
+          "assets/marked.min.js",
+          "https://cdn.jsdelivr.net/npm/marked@12/lib/marked.min.js"
+        ];
+
+        let lastError;
+        for (const source of sources) {
+          try {
+            await loadScript(source);
+            if (window.marked) {
+              return window.marked;
+            }
+          } catch (error) {
+            lastError = error;
+          }
+        }
+
+        throw lastError ?? new Error("Konvertierungsbibliothek konnte nicht geladen werden.");
+      }
+
       async function renderDocument() {
         try {
-          marked.setOptions({
+          const markedLib = await ensureMarked();
+
+          markedLib.setOptions({
             gfm: true,
             breaks: false,
             mangle: false,
@@ -81,7 +119,7 @@
             }
 
             const markdown = await response.text();
-            const html = marked.parse(markdown);
+            const html = markedLib.parse(markdown);
 
             const page = document.createElement("section");
             page.className = "page";
@@ -101,18 +139,16 @@
         } catch (error) {
           console.error(error);
           if (statusNode) {
-            statusNode.textContent = "Fehler beim Laden der Inhalte. Bitte versuchen Sie es erneut.";
+            statusNode.textContent =
+              error?.message === "Konvertierungsbibliothek konnte nicht geladen werden."
+                ? error.message
+                : "Fehler beim Laden der Inhalte. Bitte versuchen Sie es erneut.";
             statusNode.className = "error";
           }
         }
       }
 
-      if (typeof marked === "undefined") {
-        statusNode.textContent = "Konvertierungsbibliothek konnte nicht geladen werden.";
-        statusNode.className = "error";
-      } else {
-        renderDocument();
-      }
+      renderDocument();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the local marked library dynamically with a CDN fallback so GitHub Pages always gets the converter
- reuse the loaded library to render all documentation sections and show clearer status messages when loading fails

## Testing
- not run (static HTML/JS change)

------
https://chatgpt.com/codex/tasks/task_e_68e14f718d308324b3f02d3389bdeafc