### PR TITLE
feat: paginate chapters into DIN A4 pages

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -2,11 +2,13 @@
   color-scheme: light;
   font-family: "Segoe UI", Roboto, sans-serif;
   background-color: #f4f5f7;
+  --page-padding-mm: 20;
 }
 
 body {
   margin: 0;
   background: var(--page-bg, #f4f5f7);
+  line-height: 1.4;
 }
 
 header {
@@ -47,26 +49,66 @@ main {
   width: 210mm;
   min-height: 297mm;
   margin: 0 auto 2.5rem;
-  padding: 20mm;
+  padding: calc(var(--page-padding-mm) * 1mm);
   box-sizing: border-box;
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
   border-radius: 12px;
   color: #1f2933;
+  font-size: 10pt;
+  line-height: 1.45;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
 }
 
-.page > :first-child {
-  margin-top: 0;
+.page h1 {
+  margin: 0;
+  font-size: 1.65rem;
+  line-height: 1.2;
+  color: #102a43;
 }
 
-.page h1,
 .page h2,
 .page h3,
-.page h4 {
+.page h4,
+.page h5,
+.page h6 {
   color: #102a43;
 }
 
 .page a {
   color: #1d4ed8;
+}
+
+.page .page-content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.page .page-content > * {
+  margin-block: 0;
+}
+
+.page .page-content > :first-child {
+  margin-top: 0;
+}
+
+.page.page--overflow {
+  position: relative;
+}
+
+.page.page--overflow::after {
+  content: "Inhalt überlappt die Seitenhöhe";
+  position: absolute;
+  right: 1.5rem;
+  bottom: 1.2rem;
+  font-size: 0.75rem;
+  color: #b91c1c;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.4rem;
 }
 
 .page table {
@@ -100,6 +142,11 @@ footer {
     width: calc(100% - 2rem);
     min-height: auto;
     padding: 2rem;
+    font-size: 1rem;
+  }
+
+  .page .page-content {
+    gap: 1.1rem;
   }
 }
 
@@ -131,6 +178,10 @@ footer {
     box-shadow: none;
     border-radius: 0;
     page-break-after: always;
+  }
+
+  .page.page--overflow::after {
+    display: none;
   }
 
   .page:last-of-type {

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,31 @@
       const statusNode = document.getElementById("status");
       const docNode = document.getElementById("document");
 
+      const PAGE_HEIGHT_MM = 297;
+      const rootStyles = getComputedStyle(document.documentElement);
+      const pagePaddingValue = parseFloat(
+        rootStyles.getPropertyValue("--page-padding-mm")?.trim() ?? "20"
+      );
+      const PAGE_PADDING_MM = Number.isFinite(pagePaddingValue)
+        ? pagePaddingValue
+        : 20;
+
+      function getPxPerMillimeter() {
+        const probe = document.createElement("div");
+        probe.style.position = "absolute";
+        probe.style.width = "1mm";
+        probe.style.height = "1mm";
+        probe.style.visibility = "hidden";
+        document.body.appendChild(probe);
+        const { height } = probe.getBoundingClientRect();
+        document.body.removeChild(probe);
+        return height;
+      }
+
+      const pxPerMm = getPxPerMillimeter();
+      const maxContentHeightPx =
+        (PAGE_HEIGHT_MM - PAGE_PADDING_MM * 2) * pxPerMm;
+
       function loadScript(src) {
         return new Promise((resolve, reject) => {
           const script = document.createElement("script");
@@ -101,6 +126,72 @@
         throw lastError ?? new Error("Konvertierungsbibliothek konnte nicht geladen werden.");
       }
 
+      function createPage(title, continuationIndex = 0) {
+        const page = document.createElement("section");
+        page.className = "page";
+
+        const heading = document.createElement("h1");
+        if (continuationIndex === 0) {
+          heading.textContent = title;
+        } else if (continuationIndex === 1) {
+          heading.textContent = `${title} – Fortsetzung`;
+        } else {
+          heading.textContent = `${title} – Fortsetzung ${continuationIndex}`;
+        }
+        page.appendChild(heading);
+
+        const content = document.createElement("div");
+        content.className = "page-content";
+        page.appendChild(content);
+
+        docNode.appendChild(page);
+
+        return { page, content };
+      }
+
+      function appendNodeWithPagination({
+        nodes,
+        title
+      }) {
+        if (nodes.length === 0) {
+          return;
+        }
+
+        let continuationIndex = 0;
+        let { content, page } = createPage(title, continuationIndex);
+
+        const workQueue = nodes.filter(
+          (node) => !(node.nodeType === Node.TEXT_NODE && node.textContent?.trim() === "")
+        );
+
+        for (const node of workQueue) {
+          content.appendChild(node);
+          const contentHeight = content.getBoundingClientRect().height;
+
+          if (contentHeight <= maxContentHeightPx + 0.5) {
+            continue;
+          }
+
+          content.removeChild(node);
+
+          const hasContent = content.childNodes.length > 0;
+          if (!hasContent) {
+            // The node itself is higher than the available space – keep it on this page.
+            content.appendChild(node);
+            page.classList.add("page--overflow");
+            continue;
+          }
+
+          continuationIndex += 1;
+          ({ content, page } = createPage(title, continuationIndex));
+          content.appendChild(node);
+        }
+
+        if (content.childNodes.length === 0) {
+          docNode.removeChild(page);
+        }
+      }
+
       async function renderDocument() {
         try {
           const markedLib = await ensureMarked();
@@ -112,6 +203,8 @@
             headerIds: true
           });
 
+          docNode.innerHTML = "";
+
           for (const section of sections) {
             const response = await fetch(section.file);
             if (!response.ok) {
@@ -120,19 +213,12 @@
 
             const markdown = await response.text();
             const html = markedLib.parse(markdown);
-
-            const page = document.createElement("section");
-            page.className = "page";
-
-            const heading = document.createElement("h1");
-            heading.textContent = section.heading;
-            page.appendChild(heading);
-
-            const contentWrapper = document.createElement("div");
-            contentWrapper.innerHTML = html;
-            page.appendChild(contentWrapper);
-
-            docNode.appendChild(page);
+            const container = document.createElement("div");
+            container.innerHTML = html;
+            appendNodeWithPagination({
+              nodes: Array.from(container.childNodes),
+              title: section.heading
+            });
           }
 
           statusNode?.remove();


### PR DESCRIPTION
## Summary
- tune the DIN A4 base styling to use 10pt typography, shared padding variables, and structured content containers
- add client-side pagination that splits each Markdown chapter into multiple DIN A4-sized pages with continuation headings
- mark pages that still overflow so oversized elements can be spotted during reviews

## Testing
- python3 -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68e24c567d64832488491777b361f91b